### PR TITLE
add additional unit tests

### DIFF
--- a/pkg/elector.go
+++ b/pkg/elector.go
@@ -43,6 +43,8 @@ type electorNode struct {
 	ctx           context.Context
 	currentLeader string
 	quit          chan os.Signal
+
+	servingHTTP bool
 }
 
 // NewElectorNode creates a new instance of an elector node which will
@@ -238,6 +240,7 @@ func (node *electorNode) serveHTTP() {
 
 	klog.Infof("starting HTTP server on %v", node.config.Address)
 	http.HandleFunc("/", node.httpLeaderInfo)
+	node.servingHTTP = true
 	err := http.ListenAndServe(node.config.Address, nil)
 	if err != nil {
 		klog.Fatalf("failed to start the HTTP server: %v", err)

--- a/pkg/testdata/config
+++ b/pkg/testdata/config
@@ -1,0 +1,13 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://localhost:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+  name: test
+current-context: test
+kind: Config
+preferences: {}


### PR DESCRIPTION
Adds additional unit tests.

It is still unclear how to test/mock the actual election bits, as I've been unable to find docs related to that. Since it is just using the kubernetes API, that may be fine and we'll just put faith in the tests for the k8s api.