### PR TITLE
add labels to pod based on election status

### DIFF
--- a/example.yaml
+++ b/example.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8s-elector-example
+  labels:
+    app: k8s-elector
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: k8s-elector
+  template:
+    metadata:
+      name: k8s-elector-example
+      labels:
+        app: k8s-elector
+    spec:
+      terminationGracePeriodSeconds: 3
+      containers:
+        - name: k8s-elector
+          image: vaporio/k8s-elector:latest
+          imagePullPolicy: Never
+          args:
+            - -election=example-election
+            - -http=localhost:4040
+            - -ttl=3s
+            - -namespace=default
+            - -lock-type=configmaps

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -34,6 +34,11 @@ type ElectorConfig struct {
 	// using the HOSTNAME as its ID.
 	ID string
 
+	// PodName is the name of the Pod which the elector is running in. This is
+	// found via the ELECTOR_POD_NAME environment variable. If not set, this defaults
+	// to the hostname.
+	PodName string
+
 	// KubeConfig is the path to the kubeconfig file to use for setting up the
 	// elector node's Kubernetes client. If no kubeconfig is specified, the node
 	// will default to using in-cluster configuration.
@@ -73,6 +78,7 @@ func (conf *ElectorConfig) Log() {
 		klog.Infof("  ID:         %s", conf.ID)
 		klog.Infof("  Name:       %s", conf.Name)
 		klog.Infof("  Namespace:  %s", conf.Namespace)
+		klog.Infof("  PodName:    %s", conf.PodName)
 		klog.Infof("  Address:    %s", conf.Address)
 		klog.Infof("  LockType:   %s", conf.LockType)
 		klog.Infof("  KubeConfig: %s", conf.KubeConfig)


### PR DESCRIPTION
This PR:
- adds functionality to the elector to add/update labels on the Pod which the elector is running in to make it easier to determine which instance is the leader.

Example from local testing:
```console
$ kubectl get pods --show-labels
NAME                                   READY   STATUS    RESTARTS   AGE   LABELS
k8s-elector-example-78576bc4bb-29xfz   1/1     Running   0          74s   app=k8s-elector,k8s-elector/status=standby,pod-template-hash=78576bc4bb
k8s-elector-example-78576bc4bb-4zglr   1/1     Running   0          74s   app=k8s-elector,k8s-elector/status=leader,pod-template-hash=78576bc4bb
k8s-elector-example-78576bc4bb-9czrj   1/1     Running   0          74s   app=k8s-elector,k8s-elector/status=standby,pod-template-hash=78576bc4bb

$ kubectl delete pod k8s-elector-example-78576bc4bb-9czrj
pod "k8s-elector-example-78576bc4bb-9czrj" deleted

$ kubectl get pods --show-labels
NAME                                   READY   STATUS    RESTARTS   AGE   LABELS
k8s-elector-example-78576bc4bb-29xfz   1/1     Running   0          87s   app=k8s-elector,k8s-elector/status=standby,pod-template-hash=78576bc4bb
k8s-elector-example-78576bc4bb-4h7pk   1/1     Running   0          7s    app=k8s-elector,k8s-elector/status=standby,pod-template-hash=78576bc4bb
k8s-elector-example-78576bc4bb-4zglr   1/1     Running   0          87s   app=k8s-elector,k8s-elector/status=leader,pod-template-hash=78576bc4bb

$ kubectl delete pod k8s-elector-example-78576bc4bb-4zglr
pod "k8s-elector-example-78576bc4bb-4zglr" deleted

$ kubectl get pods --show-labels
NAME                                   READY   STATUS    RESTARTS   AGE    LABELS
k8s-elector-example-78576bc4bb-29xfz   1/1     Running   0          117s   app=k8s-elector,k8s-elector/status=leader,pod-template-hash=78576bc4bb
k8s-elector-example-78576bc4bb-4h7pk   1/1     Running   0          37s    app=k8s-elector,k8s-elector/status=standby,pod-template-hash=78576bc4bb
k8s-elector-example-78576bc4bb-7wwx7   1/1     Running   0          12s    app=k8s-elector,k8s-elector/status=standby,pod-template-hash=78576bc4bb
```